### PR TITLE
Add environment variable for disabling AT->DX migration.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 3.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add environment variable for disabling AT->DX migration. [jone]
 
 
 3.0.0 (2019-11-11)

--- a/izug/refegovservice/upgrades/20191031154412_archetypes_to_dexterity/upgrade.py
+++ b/izug/refegovservice/upgrades/20191031154412_archetypes_to_dexterity/upgrade.py
@@ -1,5 +1,6 @@
 from ftw.upgrade import UpgradeStep
 from ftw.upgrade.migration import InplaceMigrator
+import os
 
 
 class ArchetypesToDexterity(UpgradeStep):
@@ -9,6 +10,10 @@ class ArchetypesToDexterity(UpgradeStep):
     def __call__(self):
         self.install_upgrade_profile()
         self.ensure_profile_installed('profile-plone.app.relationfield:default')
+
+        if os.environ.get('IZUG_REFEGOVSERVICE_SKIP_DEXTERITY_MIGRATION', '').lower() == 'true':
+            return
+
         self.migrate_egovservice()
         self.migrate_refegovservice()
 

--- a/izug/refegovservice/upgrades/20191031154412_archetypes_to_dexterity/upgrade.py
+++ b/izug/refegovservice/upgrades/20191031154412_archetypes_to_dexterity/upgrade.py
@@ -8,7 +8,7 @@ class ArchetypesToDexterity(UpgradeStep):
 
     def __call__(self):
         self.install_upgrade_profile()
-        self.setup_install_profile('profile-plone.app.relationfield:default')
+        self.ensure_profile_installed('profile-plone.app.relationfield:default')
         self.migrate_egovservice()
         self.migrate_refegovservice()
 


### PR DESCRIPTION
In `izug.organisation`, we need to add behaviors to the new dexterity FTIs _before_ migrating in order to be able to set values on the behavior fields in the migration.
In order to control when the migration is executed, an environment variable is added to the upgrade step so that the migration can be skipped and started / implemented in the policy package.

I've also changed that the `plone.app.relationfield` generic setup profile is only installed when it was not installed before on this plone site, so that we do not accidentally change customizations.