### PR TITLE
Fix permission names in lawgiver action groups.

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -5,7 +5,7 @@ Changelog
 3.0.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Fix permission names in lawgiver action groups. [jone]
 
 
 3.0.1 (2019-11-11)

--- a/izug/refegovservice/lawgiver.zcml
+++ b/izug/refegovservice/lawgiver.zcml
@@ -7,12 +7,12 @@
 
     <lawgiver:map_permissions
         action_group="add"
-        permissions="izug.refegovservice: Add RefEgovService"
+        permissions="izug.refegovservice: Add RefEGovService"
         />
 
     <lawgiver:map_permissions
         action_group="add egovleistung"
-        permissions="izug.refegovservice: Add EgovLeistung"
+        permissions="izug.refegovservice: Add EGovService"
         />
 
 </configure>

--- a/izug/refegovservice/tests/test_creation.py
+++ b/izug/refegovservice/tests/test_creation.py
@@ -4,7 +4,7 @@ from ftw.testbrowser import browsing
 from izug.refegovservice.testing import IZUG_REFEGOVSERVICE_FUNCTIONAL_TESTING
 from plone.app.testing import login
 from plone.app.textfield.value import RichTextValue
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class TestCreation(TestCase):

--- a/izug/refegovservice/tests/test_overview.py
+++ b/izug/refegovservice/tests/test_overview.py
@@ -4,7 +4,7 @@ from ftw.builder import create
 from ftw.table.helper import readable_date_time_text
 from ftw.testbrowser import browsing
 from izug.refegovservice.testing import IZUG_REFEGOVSERVICE_FUNCTIONAL_TESTING
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 class TestOverview(TestCase):

--- a/izug/refegovservice/tests/test_uninstall.py
+++ b/izug/refegovservice/tests/test_uninstall.py
@@ -1,6 +1,6 @@
 from ftw.testing.genericsetup import apply_generic_setup_layer
 from ftw.testing.genericsetup import GenericSetupUninstallMixin
-from unittest2 import TestCase
+from unittest import TestCase
 
 
 @apply_generic_setup_layer


### PR DESCRIPTION
The permissions were renamed, but the lawgiver action group mapping was not updated.